### PR TITLE
GH action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+ # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v2
 
     - name: Build
       working-directory: ${{env.GITHUB_WORKSPACE}}
@@ -43,7 +43,7 @@ jobs:
       run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
 
     - name: Archive Release
-      uses: thedoctor0/zip-release@0.7.5
+      uses: thedoctor0/zip-release@0.7.6
       with:
         type: 'zip'
         filename: 'BlitzSearch-v1.0.0.3-x64.zip'
@@ -51,7 +51,7 @@ jobs:
         exclusions: '*.git* /*node_modules/* .editorconfig *.pdb'
 
     - name: Create release and upload
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -60,7 +60,7 @@ jobs:
            draft: false
            files: "src/vs/x64/Release/BlitzSearch-v1.0.0.3-x64.zip"
            tag_name: "InitialRelease"
-           
+
     - name: SHA256
       if: env.BUILD_CONFIGURATION == 'Release'
       run: sha256sum.exe src/vs/x64/Release/BlitzSearch-v1.0.0.3-x64.zip


### PR DESCRIPTION
- added dependabot.yml
- updated GH action versions to avoid warnings about:

The following actions uses node12 which is deprecated and will be forced to run on node16: microsoft/setup-msbuild@v1.0.2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/


See https://github.com/chcg/NPP_HexEdit/blob/master/.github/workflows/CI_build.yml on how to create releases automatically on tagging.