### PR TITLE
Update release build workflow

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -40,10 +40,11 @@ jobs:
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
       # run: msbuild GitSCM.vcxproj /m /p:configuration="${{ matrix.build_configuration }}" /p:platform="${{ matrix.build_platform }}" /p:PlatformToolset="v142" /target:zip
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Get release file version
       run: |
-        msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
-        # save the DLL file version for use in later steps
-        echo "DLL_VERSION=$((Get-Item .\src\vs\x64\${{env.BUILD_CONFIGURATION}}\BlitzSearch.dll).VersionInfo.FileVersion)" >> $env:GITHUB_ENV
+        echo "DLL_VERSION=$((Get-Item .\src\vs\x64\Release\BlitzSearch.dll).VersionInfo.FileVersion)" >> $env:GITHUB_ENV
 
     - name: Archive Release
       uses: thedoctor0/zip-release@0.7.6
@@ -51,9 +52,10 @@ jobs:
         type: 'zip'
         filename: 'BlitzSearch-v${{ env.DLL_VERSION }}-x64.zip'
         directory: 'src/vs/x64/Release'
-        exclusions: '*.git* /*node_modules/* .editorconfig *.pdb'
+        exclusions: '*.git* /*node_modules/* .editorconfig *.exp *.lib *.pdb'
 
     - name: Create release and upload
+      if: ${{ contains(github.ref, 'tags') }}
       uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -62,7 +64,8 @@ jobs:
            prerelease: false
            draft: false
            files: "src/vs/x64/Release/BlitzSearch-v${{ env.DLL_VERSION }}-x64.zip"
-           tag_name: "InitialRelease"
+           tag_name: "${{ github.ref_name }}"
+           name: "BlitzSearch - ${{ github.ref_name }}"
 
     - name: SHA256
       if: env.BUILD_CONFIGURATION == 'Release'

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -40,13 +40,16 @@ jobs:
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
       # run: msbuild GitSCM.vcxproj /m /p:configuration="${{ matrix.build_configuration }}" /p:platform="${{ matrix.build_platform }}" /p:PlatformToolset="v142" /target:zip
-      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+      run: |
+        msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+        # save the DLL file version for use in later steps
+        echo "DLL_VERSION=$((Get-Item .\src\vs\x64\${{env.BUILD_CONFIGURATION}}\BlitzSearch.dll).VersionInfo.FileVersion)" >> $env:GITHUB_ENV
 
     - name: Archive Release
       uses: thedoctor0/zip-release@0.7.6
       with:
         type: 'zip'
-        filename: 'BlitzSearch-v1.0.0.3-x64.zip'
+        filename: 'BlitzSearch-v${{ env.DLL_VERSION }}-x64.zip'
         directory: 'src/vs/x64/Release'
         exclusions: '*.git* /*node_modules/* .editorconfig *.pdb'
 
@@ -58,9 +61,10 @@ jobs:
            generate_release_notes: true
            prerelease: false
            draft: false
-           files: "src/vs/x64/Release/BlitzSearch-v1.0.0.3-x64.zip"
+           files: "src/vs/x64/Release/BlitzSearch-v${{ env.DLL_VERSION }}-x64.zip"
            tag_name: "InitialRelease"
 
     - name: SHA256
       if: env.BUILD_CONFIGURATION == 'Release'
-      run: sha256sum.exe src/vs/x64/Release/BlitzSearch-v1.0.0.3-x64.zip
+      shell: bash
+      run: sha256sum.exe src/vs/x64/Release/BlitzSearch-v${{ env.DLL_VERSION }}-x64.zip

--- a/src/vs/BlitzSearchNpp.vcxproj
+++ b/src/vs/BlitzSearchNpp.vcxproj
@@ -54,7 +54,7 @@
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;NPPPLUGINDEMO_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;NPPPLUGINDEMO_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <TreatWarningAsError>true</TreatWarningAsError>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -73,16 +73,19 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;NPPPLUGINDEMO_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;NPPPLUGINDEMO_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <Optimization>MaxSpeed</Optimization>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
       <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
       <AssemblyDebug>false</AssemblyDebug>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
Prior releases did not strip debug info from the DLL. Since malware executables usually contain instrumentation code for remote command-and-control operations, the presence of debugging code probably explains the plugin's lousy reputation score: #3

Compare [this report] of a clean, optimized DLL built in release mode.

[this report]: https://www.virustotal.com/gui/file/d038696407902676dd9632dfe60357d00aa28ad9687c9a5d878133a8a519c503

This also:

* adds the `_CRT_SECURE_NO_WARNINGS` compiler definition so builds don't fail because the `/WX` flag is set and legacy functions like `wcscat` will definitely raise warnings;

* fixes a failing step in the workflow and makes it usable for any future version; I would suggest also making the `tag_name` input to the `softprops/action-gh-release` action variable, but left it alone for now.