### PR TITLE
Always publish a release

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -55,6 +55,7 @@ jobs:
         exclusions: '*.git* /*node_modules/* .editorconfig *.exp *.lib *.pdb'
 
     - name: Create release and upload
+      if: ${{ github.event_name == 'push' }}
       uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -55,7 +55,6 @@ jobs:
         exclusions: '*.git* /*node_modules/* .editorconfig *.exp *.lib *.pdb'
 
     - name: Create release and upload
-      if: ${{ contains(github.ref, 'tags') }}
       uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -64,8 +63,8 @@ jobs:
            prerelease: false
            draft: false
            files: "src/vs/x64/Release/BlitzSearch-v${{ env.DLL_VERSION }}-x64.zip"
-           tag_name: "${{ github.ref_name }}"
-           name: "BlitzSearch - ${{ github.ref_name }}"
+           tag_name: "v${{ env.DLL_VERSION }}"
+           name: "BlitzSearch - v${{ env.DLL_VERSION }}"
 
     - name: SHA256
       if: env.BUILD_CONFIGURATION == 'Release'


### PR DESCRIPTION
Like I [said before](https://github.com/Natestah/BlitsNppPlugin/pull/6#discussion_r2030193886), the release step was conditional on the __*pre*__&#x200d;-existence of a git tag, which you have to create and push from a terminal, since GitHub [can't do this automatically](https://github.com/orgs/community/discussions/48462).

It should work the way the it used to after this fix.